### PR TITLE
adds more information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "type": "git",
     "url": "git+https://github.com/theZieger/cookiejs.js.git"
   },
+  "keywords": ["cookies", "client", "browser"],
+  "contributers": [
+    "Daniel Opitz <contact@copynpaste.de> (https://copynpaste.de/)",
+  ],
+  "files": "cookiejs.js",
   "keywords": [],
   "author": "thezieger",
   "license": "MIT",


### PR DESCRIPTION
This PR adds more information to the `package.json` to name all aditional contributers, list files that should be included in the package when published and installed and keywords to enhance the package discoverability on npm/yarn.